### PR TITLE
Verify page object interactions work when using `within`

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ for standard Capybara interaction within tests.
 
 ## Roadmap
 
-* [ ] Verify page object interactions work within `within`
+* [x] Verify page object interactions work within `within`
 * [ ] Define `form` syntax
 * [ ] Define `define` syntax (FactoryBot style)
 * [ ] "Unsafe" short-circuit for verifying elements aren't present on the page (e.g. `find("selector", count: 0)`)

--- a/lib/page_ez/page.rb
+++ b/lib/page_ez/page.rb
@@ -12,7 +12,7 @@ module PageEz
 
     def method_missing(method_name, *args, &block)
       if container.respond_to?(method_name)
-        if args.length == 1
+        if args.length < 2
           container.send(method_name, *args, &block)
         else
           container.send(method_name, args.first, **args.last, &block)


### PR DESCRIPTION
What?
=====

This adds a test verifying Capybara's `within` nesting works as expected
with page objects.