### PR TITLE
Add method for asserting has_many count while waiting for JS

### DIFF
--- a/lib/page_ez/page.rb
+++ b/lib/page_ez/page.rb
@@ -65,6 +65,13 @@ module PageEz
           decorate_element_with_block(element, &block)
         end
       end
+
+      define_method("has_#{name}_count?") do |count, *args|
+        has_css?(
+          selector,
+          **process_options(options, dynamic_options, *args).merge(count: count)
+        )
+      end
     end
 
     private

--- a/spec/features/capybara_javascript_spec.rb
+++ b/spec/features/capybara_javascript_spec.rb
@@ -46,6 +46,57 @@ RSpec.describe "Capybara and JavaScript", type: :feature do
     expect(Time.now - start_time).to be_between(1.45, 2.5)
   end
 
+  it "allows for counting elements while waiting" do
+    page = build_page(<<-HTML)
+    <template id="item">
+      <li></li>
+    </template>
+
+    <section>
+      <ul>
+        <li>Item 1</li>
+      </ul>
+    </section>
+
+    <script type="text/javascript">
+      function generateItem(title, target) {
+        const template = document.querySelector("template#item");
+        const item = template.content.cloneNode(true);
+        item.querySelector("li").textContent = title;
+
+        target.appendChild(item);
+      }
+
+      document.addEventListener("DOMContentLoaded", () => {
+        const target = document.querySelector("section ul");
+
+        setTimeout(() => {
+          generateItem("Item 2", target);
+          generateItem("Item 3", target);
+          generateItem("Item 4", target);
+        }, 1500);
+      });
+    </script>
+    HTML
+
+    test_page = Class.new(PageEz::Page) do
+      has_one :list, "ul" do
+        has_many :items, "li"
+      end
+    end.new(page)
+
+    page.visit "/"
+
+    with_max_wait_time(seconds: 1) do
+      expect(test_page.list).to have_items_count(1)
+      expect(test_page.list.items.count).to eq(1)
+    end
+
+    with_max_wait_time(seconds: 2) do
+      expect(test_page.list).to have_items_count(4)
+    end
+  end
+
   def build_page(markup)
     AppGenerator
       .new


### PR DESCRIPTION
What?
=====

This introduces a new method, `#has_{name}_count?`, to allow for
asserting count on a has_many that waits for Capybara to find the
element on the page by using `has_css?` with a defined count argument.
