### PR TITLE
Add has_many_ordered to support additional positioned elements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
+    launchy (2.5.2)
+      addressable (~> 2.8)
     lint_roller (1.0.0)
     matrix (0.4.2)
     mini_mime (1.1.2)
@@ -122,6 +124,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  launchy (~> 2.5)
   page_ez!
   puma (~> 6.3)
   rake (~> 13.0)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,34 @@ class TodosIndex < PageEz::Page
 end
 ```
 
+### `has_many_ordered`
+
+This mirrors the `has_many` macro but adds additional methods for accessing
+elements at a specific index.
+
+```rb
+class TodosIndex < PageEz::Page
+  has_many_ordered :todos, "ul[data-role=todo-list] li" do
+    has_one :title, "span[data-role=todo-title]"
+    has_one :complete, "input[type=checkbox][data-role=mark-complete]"
+
+    def complete?
+      complete.checked?
+    end
+  end
+end
+
+todos_index = TodosIndex.new
+
+expect(todos_index.todo_at(0)).to have_text("Buy milk")
+# or
+expect(todos_index).to have_todo_at(0, text: "Buy milk")
+
+todos_index.todo_at(0).complete.click
+
+expect(todos_index.todo_at(0)).to be_complete
+```
+
 While the gem is under active development and the APIs are being determined,
 it's best to review the feature specs to understand how to use the gem.
 

--- a/page_ez.gemspec
+++ b/page_ez.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sinatra", "~> 3.0"
   spec.add_development_dependency "selenium-webdriver", "~> 4.10"
   spec.add_development_dependency "puma", "~> 6.3"
+  spec.add_development_dependency "launchy", "~> 2.5"
 end

--- a/spec/features/has_many_ordered_spec.rb
+++ b/spec/features/has_many_ordered_spec.rb
@@ -1,0 +1,101 @@
+require "spec_helper"
+
+RSpec.describe "has_many_ordered", type: :feature do
+  it "allows for selection at an index" do
+    page = build_page(<<-HTML)
+    <template id="item">
+      <li>
+        <span data-role="title"></span>
+        <input type="checkbox" name="complete" />
+      </li>
+    </template>
+
+    <section>
+      <ul>
+        <li>
+          <span data-role="title">Item 1</span>
+          <input type="checkbox" name="complete" />
+        </li>
+      </ul>
+    </section>
+
+    <script type="text/javascript">
+      function generateItem(title, target) {
+        const template = document.querySelector("template#item");
+        const item = template.content.cloneNode(true);
+        item.querySelector("span[data-role=title]").textContent = title;
+
+        target.appendChild(item);
+      }
+
+      document.addEventListener("DOMContentLoaded", () => {
+        const target = document.querySelector("section ul");
+
+        setTimeout(() => {
+          generateItem("Item 2", target);
+          generateItem("Item 3", target);
+          generateItem("Item 4", target);
+        }, 250);
+      });
+    </script>
+    HTML
+
+    test_page = Class.new(PageEz::Page) do
+      has_one :list, "section ul" do
+        has_many_ordered :items, "li" do
+          has_one :title, "span[data-role=title]"
+        end
+      end
+    end.new(page)
+
+    page.visit "/"
+
+    expect(test_page.list.items[0]).not_to be_nil
+
+    expect(test_page.list.items[1]).to be_nil
+    expect(test_page.list.items[2]).to be_nil
+    expect(test_page.list.items[3]).to be_nil
+
+    page.visit "/"
+
+    expect(test_page.list.item_at(0)).to have_content("Item 1")
+    expect(test_page.list.item_at(1)).to have_content("Item 2")
+    expect(test_page.list.item_at(2)).to have_content("Item 3")
+    expect(test_page.list.item_at(3)).to have_content("Item 4")
+
+    page.visit "/"
+
+    expect(test_page.list.item_at(0).title).to have_text("Item 1")
+    expect(test_page.list.item_at(1).title).to have_text("Item 2")
+    expect(test_page.list.item_at(2).title).to have_text("Item 3")
+    expect(test_page.list.item_at(3).title).to have_text("Item 4")
+
+    page.visit "/"
+
+    expect(test_page.list).to have_item_at(0, text: "Item 1")
+    expect(test_page.list).to have_item_at(1, text: "Item 2")
+    expect(test_page.list).to have_item_at(2, text: "Item 3")
+    expect(test_page.list).to have_item_at(3, text: "Item 4")
+
+    page.visit "/"
+
+    expect(test_page.list).to have_items_count(4)
+
+    expect do
+      test_page.list.item_at(4)
+    end.to raise_error(Capybara::ElementNotFound)
+
+    page.visit "/"
+
+    with_max_wait_time(seconds: 0.1) do
+      expect(test_page.list.item_at(2, wait: 1).title).to have_text("Item 3")
+    end
+  end
+
+  def build_page(markup)
+    AppGenerator
+      .new
+      .route("/", markup)
+      .run(runner: :selenium_chrome_headless)
+  end
+end


### PR DESCRIPTION
What?
=====

In cases where we're using a `has_many`, it may be necessary to assert
against the ordering positions of values in a manner that honors
Capybara's max wait time.

Imagine a list of todos that loads items via JS when the page is done
loading. Asserting against the raw count from a `has_many` will not wait
for JavaScript by default, and moreover, accessing via an index also
fails.

This introduces `has_many_ordered`, which extends `has_many` by adding
the following additional methods:

* #{name.singularized}_at(index)
* has_#{name.singularized}_with_content_at?(index, text)
* has_no_#{name.singularized}_with_content_at?(index, text)

This uses the :nth-of-type() pseudo-selector behind the scenes in a crude
fashion (appending at the end of the selector) and handles the 0-based index
to 1-based index shift as well.

Consider the following page object:

```rb
class TodoListPage < PageEz::Page
  has_one :list, "ul" do
    has_many_ordered :todos, "li" do
      has_one :title, "[data-role=title]"
      has_one :complete_box, "input[type=checkbox]"
    end
  end
end
```

And markup:

```html
<ul>
  <li data-global-id="gid://todos/Todo/1">
    <span data-role="title">Buy milk</span>
    <input type="checkbox" name="complete" />
  </li>

  <li data-global-id="gid://todos/Todo/2">
    <span data-role="title">Buy eggs</span>
    <input type="checkbox" name="complete" />
  </li>
</ul>

```

This allows for the following assertions:

```rb
todo_list_page = TodoListPage.new

expect(todo_list_page.list.todo_at(0).title).to have_text("Buy milk")
expect(todo_list_page.list.todo_at(1).title).to have_text("Buy eggs")

expect(todo_list_page.list).to have_todo_with_content_at(0, "Buy milk")
expect(todo_list_page.list).to have_todo_with_content_at(1, "Buy eggs")

expect(todo_list_page.list).to have_no_todo_with_content_at(1, "Buy milk")
```

Hacks / Caveats
===============

This behavior is currently hidden behind the new `has_many_ordered` due
to potential issues with this implementation, including:

* using ActiveSupport's inflection rules for singularizing the has_many;
  this assumes that the symbol is already pluralized
* adjusting the 0- to 1-based index implicitly, which may confuse
  developers who know that this uses nth-of-type
* appending nth-of-type to the end of the selector
