### PR TITLE
Update occurrences of method_missing with improved approach

### DIFF
--- a/lib/page_ez/has_many_result.rb
+++ b/lib/page_ez/has_many_result.rb
@@ -21,9 +21,9 @@ module PageEz
 
     private
 
-    def method_missing(method_name, *args, &block)
-      if @result.respond_to?(method_name)
-        @result.send(method_name, *args, &block)
+    def method_missing(*args, **kwargs, &block)
+      if @result.respond_to?(args[0])
+        @result.send(*args, **kwargs, &block)
       else
         super
       end

--- a/lib/page_ez/has_one_result.rb
+++ b/lib/page_ez/has_one_result.rb
@@ -11,10 +11,12 @@ module PageEz
 
     private
 
-    def method_missing(...)
-      @result.send(...)
-    rescue NoMethodError
-      super(...)
+    def method_missing(*args, **kwargs, &block)
+      if @result.respond_to?(args[0])
+        @result.send(*args, **kwargs, &block)
+      else
+        super
+      end
     end
 
     def respond_to_missing?(method_name, include_private = false)

--- a/lib/page_ez/page.rb
+++ b/lib/page_ez/page.rb
@@ -11,13 +11,9 @@ module PageEz
       end.new
     end
 
-    def method_missing(method_name, *args, &block)
-      if container.respond_to?(method_name)
-        if args.length < 2
-          container.send(method_name, *args, &block)
-        else
-          container.send(method_name, args.first, **args.last, &block)
-        end
+    def method_missing(*args, **kwargs, &block)
+      if container.respond_to?(args[0])
+        container.send(*args, **kwargs, &block)
       else
         super
       end


### PR DESCRIPTION
What?
=====

Rather than call `target.send(...)` and rescue, this adjusts delegation
to follow guidance outlined in https://bugs.ruby-lang.org/issues/16157.

Because the gem only supports Ruby versions >= 3.0, this bypasses the
Ruby 2 support path as it's unnecessary.
