### PR TITLE
Introduce internal logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,20 @@ expect(todos_index.todo_at(0)).to be_complete
 While the gem is under active development and the APIs are being determined,
 it's best to review the feature specs to understand how to use the gem.
 
+## Configuration
+
+### Logger
+
+Configure PageEz's logger to capture debugging information about
+which page objects and methods are defined.
+
+
+```rb
+PageEz.configure do |config|
+  config.logger = Logger.new($stdout)
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run

--- a/lib/page_ez.rb
+++ b/lib/page_ez.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative "page_ez/version"
+require_relative "page_ez/configuration"
+require_relative "page_ez/null_logger"
 require_relative "page_ez/page"
 require_relative "page_ez/options"
 require_relative "page_ez/has_one_result"
@@ -8,4 +10,12 @@ require_relative "page_ez/has_many_result"
 
 module PageEz
   class Error < StandardError; end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield configuration if block_given?
+  end
 end

--- a/lib/page_ez/configuration.rb
+++ b/lib/page_ez/configuration.rb
@@ -1,0 +1,9 @@
+module PageEz
+  class Configuration
+    attr_accessor :logger
+
+    def initialize
+      @logger = NullLogger.new
+    end
+  end
+end

--- a/lib/page_ez/null_logger.rb
+++ b/lib/page_ez/null_logger.rb
@@ -1,0 +1,12 @@
+module PageEz
+  class NullLogger
+    def debug(*)
+    end
+
+    def info(*)
+    end
+
+    def warn(*)
+    end
+  end
+end

--- a/spec/lib/page_ez/page_spec.rb
+++ b/spec/lib/page_ez/page_spec.rb
@@ -1,0 +1,108 @@
+require "spec_helper"
+require "logger"
+
+RSpec.describe PageEz::Page do
+  it "logs declarations" do
+    logger = configure_fake_logger
+
+    Class.new(PageEz::Page) do
+      has_one :list, "ul" do
+        has_many :items, "li" do
+          has_one :name, "span"
+        end
+      end
+    end
+
+    expect(logger.debugs).to contain_in_order(
+      "has_one :list, \"ul\"",
+      "  has_many :items, \"li\"",
+      "    has_one :name, \"span\""
+    )
+
+    logger.reset
+
+    Class.new(PageEz::Page) do
+      has_one :dashboard, "section" do
+        has_many :cards, "li[data-role=card]" do
+          has_one :title, "h3"
+        end
+
+        has_many_ordered :contacts, "li[data-role=contact]" do
+          has_one :name, "h3"
+        end
+      end
+    end
+
+    expect(logger.debugs).to contain_in_order(
+      "has_one :dashboard, \"section\"",
+      "  has_many :cards, \"li[data-role=card]\"",
+      "    has_one :title, \"h3\"",
+      "  has_many_ordered :contacts, \"li[data-role=contact]\"",
+      "    has_one :name, \"h3\""
+    )
+  end
+
+  it "logs page object names" do
+    logger = configure_fake_logger
+
+    # rubocop:disable Lint/ConstantDefinitionInBlock
+    class Homepage < PageEz::Page
+    end
+
+    class TodosIndex < PageEz::Page
+    end
+
+    module Nested
+      class Dashboard < PageEz::Page
+      end
+
+      class LoggedInDashboard < Dashboard
+      end
+    end
+    # rubocop:enable Lint/ConstantDefinitionInBlock
+
+    Class.new(PageEz::Page)
+
+    expect(logger.debugs).to contain_in_order(
+      "Declaring page object: Homepage",
+      "Declaring page object: TodosIndex",
+      "Declaring page object: Nested::Dashboard",
+      "Declaring page object: Nested::LoggedInDashboard",
+      "Declaring page object: {anonymous page object}"
+    )
+  end
+
+  def configure_fake_logger
+    logger = Class.new do
+      attr_reader :debugs, :infos, :warns
+
+      def initialize
+        reset
+      end
+
+      def debug(message)
+        @debugs << message
+      end
+
+      def info(message)
+        @infos << message
+      end
+
+      def warn(message)
+        @warns << message
+      end
+
+      def reset
+        @debugs = []
+        @infos = []
+        @warns = []
+      end
+    end.new
+
+    PageEz.configure do |config|
+      config.logger = logger
+    end
+
+    logger
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require "sinatra/base"
 require "capybara/rspec"
 require_relative "support/app_generator"
 require_relative "support/capybara"
+require_relative "support/matchers/contain_in_order"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -15,5 +16,15 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  config.around do |example|
+    old_logger = PageEz.configuration.logger
+
+    example.run
+  ensure
+    PageEz.configure do |config|
+      config.logger = old_logger
+    end
   end
 end

--- a/spec/support/matchers/contain_in_order.rb
+++ b/spec/support/matchers/contain_in_order.rb
@@ -1,0 +1,13 @@
+RSpec::Matchers.define :contain_in_order do |*expected|
+  match do |actual|
+    actual_ = actual.dup
+
+    result = expected.map do |expected_|
+      actual_.index(expected_).tap do |index|
+        actual_.delete_at(index) if index
+      end
+    end
+
+    result == result.compact && result == result.sort
+  end
+end


### PR DESCRIPTION
What?
=====

This introduces basic configuration and the first configuration option:
logging.

This allows the developer to provide a logger to PageEz, which currently
logs out page object definitions, declarations, and method definitions.
