### PR TITLE
Undefine `select` on PageEz::Page so Capybara behavior works

### DIFF
--- a/lib/page_ez/page.rb
+++ b/lib/page_ez/page.rb
@@ -5,6 +5,7 @@ module PageEz
   class Page
     class_attribute :depth
     self.depth = 0
+    undef_method :select
 
     attr_reader :container
 

--- a/spec/features/form_spec.rb
+++ b/spec/features/form_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+RSpec.describe "Form interactions", type: :feature do
+  it "works with selects" do
+    page = build_page(<<-HTML)
+    <form>
+      <select id="options">
+        <option value="1">One</option>
+        <option value="2">Two</option>
+      </select>
+    </form>
+    HTML
+
+    test_page = Class.new(PageEz::Page) do
+      has_one :form, "form" do
+        has_one :options, "select#options"
+
+        def select_thing(value)
+          select value, from: "options"
+        end
+      end
+    end.new(page)
+
+    page.visit "/"
+
+    test_page.form.select_thing("One")
+    test_page.form.select_thing("Two")
+  end
+
+  def build_page(markup)
+    AppGenerator
+      .new
+      .route("/", markup)
+      .run
+  end
+end


### PR DESCRIPTION
What?
=====

This introduces a test and undefines the `select` method (defined in
`Kernel`) to allow for Capybara's `select` method to behave as expected.
