### PR TITLE
Update target ruby version to 3.0

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,3 +1,3 @@
 # For available configuration options, see:
 #   https://github.com/testdouble/standard
-ruby_version: 2.6
+ruby_version: 3.0


### PR DESCRIPTION
With the existing `ruby_version: 2.6`, the following error is reported:

```
[Lint/Syntax] unexpected token kIN(Using Ruby 2.6 parser; configure
using `TargetRubyVersion` parameter, under `AllCops`) standardrb [36, 7]
```

The gemspec's `required_ruby_version` is set to `>= 3.0.0` so I set the target ruby version to 3.0.