### PR TITLE
Raise when duplicate attributes are declared on the same page object

### DIFF
--- a/lib/page_ez.rb
+++ b/lib/page_ez.rb
@@ -14,6 +14,8 @@ module PageEz
 
   class PluralizationMismatchError < StandardError; end
 
+  class DuplicateElementDeclarationError < StandardError; end
+
   def self.configuration
     @configuration ||= Configuration.new
   end

--- a/spec/features/smoke_spec.rb
+++ b/spec/features/smoke_spec.rb
@@ -31,4 +31,13 @@ RSpec.describe "Smoke spec", type: :feature do
       end
     end.to raise_error(NoMethodError, /has_many1/)
   end
+
+  it "raises when multiple macros are declared with the same name" do
+    expect do
+      Class.new(PageEz::Page) do
+        has_one :list, "ul"
+        has_many :list, "ul li"
+      end
+    end.to raise_error(PageEz::DuplicateElementDeclarationError, /list/)
+  end
 end


### PR DESCRIPTION
What?
=====

This introduces a check so duplicate attributes can't be declared for a
given page object by raising a
`PageEz::DuplicateElementDeclarationError`
