### PR TITLE
Allow omitting or using a Symbol for selectors

### DIFF
--- a/lib/page_ez/page.rb
+++ b/lib/page_ez/page.rb
@@ -27,6 +27,7 @@ module PageEz
       in [2, _] then selector, dynamic_options = args
       in [1, Class] then composed_class = args.first
       in [1, String] | [1, Symbol] then selector = args.first.to_s
+      in [0, _] then selector = name.to_s
       end
 
       visitor.process_macro(:has_one, name, selector)

--- a/lib/page_ez/page.rb
+++ b/lib/page_ez/page.rb
@@ -26,7 +26,7 @@ module PageEz
       case [args.length, args.first]
       in [2, _] then selector, dynamic_options = args
       in [1, Class] then composed_class = args.first
-      in [1, String] then selector = args.first
+      in [1, String] | [1, Symbol] then selector = args.first.to_s
       end
 
       visitor.process_macro(:has_one, name, selector)

--- a/spec/features/selectors_spec.rb
+++ b/spec/features/selectors_spec.rb
@@ -29,6 +29,20 @@ RSpec.describe "Selectors" do
     expect(test_page).to have_heading
   end
 
+  it "uses the element name as a selector when one isn't given" do
+    page = build_page(<<-HTML)
+    <heading>Hello</heading>
+    HTML
+
+    test_page = Class.new(PageEz::Page) do
+      has_one :heading
+    end.new(page)
+
+    page.visit "/"
+
+    expect(test_page).to have_heading
+  end
+
   def build_page(markup)
     AppGenerator
       .new

--- a/spec/features/selectors_spec.rb
+++ b/spec/features/selectors_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+RSpec.describe "Selectors" do
+  it "allows string selectors" do
+    page = build_page(<<-HTML)
+    <h1>Hello</h1>
+    HTML
+
+    test_page = Class.new(PageEz::Page) do
+      has_one :heading, "h1"
+    end.new(page)
+
+    page.visit "/"
+
+    expect(test_page).to have_heading
+  end
+
+  it "allows symbol selectors" do
+    page = build_page(<<-HTML)
+    <h1>Hello</h1>
+    HTML
+
+    test_page = Class.new(PageEz::Page) do
+      has_one :heading, :h1
+    end.new(page)
+
+    page.visit "/"
+
+    expect(test_page).to have_heading
+  end
+
+  def build_page(markup)
+    AppGenerator
+      .new
+      .route("/", markup)
+      .run
+  end
+end


### PR DESCRIPTION
## Allow Symbols to be used as selectors

This commit allows using a Symbol as a selector. The symbol is converted
to a String using `to_s`.

```ruby
class TodoIndex < PageEz::Page
  has_one :heading, :h1
end
```

```ruby
todo_index = TodoIndex.new

expect(todo_index).to have_heading(text: "Hello")
```

## Fall back to element name with no selector

In cases where a page is utilizing semantic elements, it is convenient
to be able to omit the selector and use the semantic element name as the
selector.

```ruby
class PageWithSidebar < PageEz::Page
  has_one :sidebar, "aside"
  has_one :main do
    has_one :header do
      has_one :heading, "h1"
    end
    has_one :content, "section"
  end
end
```