### PR TITLE
Adjust DelegatesTo to mix in a module rather than define methods directly

### DIFF
--- a/lib/page_ez/delegates_to.rb
+++ b/lib/page_ez/delegates_to.rb
@@ -3,19 +3,21 @@ module PageEz
     def self.[](name)
       Module.new do
         define_singleton_method(:included) do |base|
-          base.class_eval %{
-            def method_missing(*args, **kwargs, &block)
-              if #{name}.respond_to?(args[0])
-                #{name}.send(*args, **kwargs, &block)
-              else
-                super(*args, **kwargs, &block)
+          base.include(Module.new.tap do |mod|
+            mod.class_eval %{
+              def method_missing(*args, **kwargs, &block)
+                if #{name}.respond_to?(args[0])
+                  #{name}.send(*args, **kwargs, &block)
+                else
+                  super(*args, **kwargs, &block)
+                end
               end
-            end
 
-            def respond_to_missing?(method_name, include_private = false)
-              #{name}.respond_to?(method_name, include_private) || super(method_name, include_private)
-            end
-          }, __FILE__, __LINE__ - 12
+              def respond_to_missing?(method_name, include_private = false)
+                #{name}.respond_to?(method_name, include_private) || super(method_name, include_private)
+              end
+            }, __FILE__, __LINE__ - 12
+          end)
         end
       end
     end


### PR DESCRIPTION
What?
=====

The previous version of DelegatesTo generated an anonymous module that,
when included, would define methods directly on the object that included
it.

This commit adjusts the behavior slightly to include a new module with
method_missing and respond_to_missing? defined, allowing for the object
including the module to call super to bubble up delegation behavior.
