### PR TITLE
Support string-ifying selectors when > 1 arg to has_one

### DIFF
--- a/lib/page_ez/page.rb
+++ b/lib/page_ez/page.rb
@@ -24,7 +24,7 @@ module PageEz
       composed_class = nil
 
       case [args.length, args.first]
-      in [2, _] then selector, dynamic_options = args
+      in [2, _] then selector, dynamic_options = [args[0].to_s, args[1]]
       in [1, Class] then composed_class = args.first
       in [1, String] | [1, Symbol] then selector = args.first.to_s
       in [0, _] then selector = name.to_s

--- a/spec/features/selectors_spec.rb
+++ b/spec/features/selectors_spec.rb
@@ -29,6 +29,21 @@ RSpec.describe "Selectors" do
     expect(test_page).to have_heading
   end
 
+  it "allows symbol selectors with dynamic options" do
+    page = build_page(<<-HTML)
+    <h1>Hello</h1>
+    HTML
+
+    test_page = Class.new(PageEz::Page) do
+      has_one :heading, :h1, ->(name) { {text: name} }
+    end.new(page)
+
+    page.visit "/"
+
+    expect(test_page).to have_heading("Hello")
+    expect(test_page).not_to have_heading("Bogus")
+  end
+
   it "uses the element name as a selector when one isn't given" do
     page = build_page(<<-HTML)
     <heading>Hello</heading>


### PR DESCRIPTION
What?
=====

This stringifies the selector passed for has_one when the selector is a
symbol.
