### PR TITLE
Generate an HTML coverage report locally

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,14 @@ end
 SimpleCov.start do
   add_filter "spec/"
 
-  formatter SimpleCov::Formatter::LcovFormatter
+  if ENV["CI"]
+    formatter SimpleCov::Formatter::LcovFormatter
+  else
+    formatter SimpleCov::Formatter::MultiFormatter.new([
+      SimpleCov::Formatter::SimpleFormatter,
+      SimpleCov::Formatter::HTMLFormatter
+    ])
+  end
 end
 
 require "page_ez"


### PR DESCRIPTION
This commit changes the SimpleCov formatter depending on the environment it is run in. In CI (when `ENV["CI"]` is truthy), it will use the exisitng LcovFormatter. When not in CI, it will use the SimpleFormatter and HTMLFormatter.

This allows for easy coverage viewing when developing locally to see how test changes affect coverage.

If there's already a means to view coverage locally with the LcovFormatter, I'm happy to update this PR to instead include documentation.