### PR TITLE
Add arm64-darwin-22 platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
When running bundle install my machine's platform is added to the Gemfile.lock file.

Running `bundle platform` gives the output:

> → bundle platform
> Your platform is: arm64-darwin-22
>
> Your app has gems that work on these platforms:
> * arm64-darwin-21
> * arm64-darwin-22
> * x86_64-linux

I believe this is okay to commit as it indicates that the gem dependencies are all available on `arm64-darwin-22`.