### PR TITLE
Extract the build_page test helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,20 +373,21 @@ git commits and the created tag, and push the `.gem` file to
 ## Feature Tests
 
 This uses a test harness for Rack app generation called `AppGenerator`, which
-handles mounting HTML responses to endpoints accessible via `GET`.
+handles mounting HTML responses to endpoints accessible via `GET`. In tests,
+call `build_page` with the markup you'd like and it will mount that response to
+the root of the application.
 
 ```ruby
-def page
-  @app ||= AppGenerator
-    .new
-    .route("/", "Hello, strange!")
-    .route("/hello", "<h1>Hello, world!</h1>")
-    .run
-end
+page = build_page(<<-HTML)
+  <form>
+    <input name="name" type="text" />
+    <input name="email" type="text" />
+  </form>
+HTML
 ```
 
-To run tests, either define `page` (via `def page` or RSpec's `let`) to allow
-for standard Capybara interaction within tests.
+To drive interactions with a headless browser, add the RSpec metadata `:js` to
+either individual `it`s or `describe`s.
 
 ## Roadmap
 

--- a/spec/features/arguments_spec.rb
+++ b/spec/features/arguments_spec.rb
@@ -31,11 +31,4 @@ RSpec.describe "Arguments" do
     expect(test_page).not_to have_heading_with_required_args_and_kwarg("Hello", 2, visible: true)
     expect(test_page).to have_heading_with_hash_arg(text: "Hello")
   end
-
-  def build_page(markup)
-    AppGenerator
-      .new
-      .route("/", markup)
-      .run
-  end
 end

--- a/spec/features/capybara_javascript_spec.rb
+++ b/spec/features/capybara_javascript_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe "Capybara and JavaScript", type: :feature do
+RSpec.describe "Capybara and JavaScript", :js, type: :feature do
   it "behaves as expected when using has_css? and has_no_css?" do
     page = build_page(<<-HTML)
     <section>
@@ -149,12 +149,5 @@ RSpec.describe "Capybara and JavaScript", type: :feature do
 
       expect(test_page.list.items).to have_count_of(4)
     end
-  end
-
-  def build_page(markup)
-    AppGenerator
-      .new
-      .route("/", markup)
-      .run(runner: :selenium_chrome_headless)
   end
 end

--- a/spec/features/composition_spec.rb
+++ b/spec/features/composition_spec.rb
@@ -71,13 +71,10 @@ RSpec.describe "Page object composition", type: :feature do
   end
 
   def build_page(markup)
-    AppGenerator
-      .new
-      .route("/", markup)
-      .run.tap do |session|
-        # this simulates more standard Rails testing behavior, where a `page`
-        # isn't assigned to explicitly.
-        allow(Capybara).to receive(:current_session).and_return(session)
-      end
+    super(markup).tap do |session|
+      # this simulates more standard Rails testing behavior, where a `page`
+      # isn't assigned to explicitly.
+      allow(Capybara).to receive(:current_session).and_return(session)
+    end
   end
 end

--- a/spec/features/form_spec.rb
+++ b/spec/features/form_spec.rb
@@ -26,11 +26,4 @@ RSpec.describe "Form interactions", type: :feature do
     test_page.form.select_thing("One")
     test_page.form.select_thing("Two")
   end
-
-  def build_page(markup)
-    AppGenerator
-      .new
-      .route("/", markup)
-      .run
-  end
 end

--- a/spec/features/has_many_ordered_spec.rb
+++ b/spec/features/has_many_ordered_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "has_many_ordered", type: :feature do
     # expect(test_page.webhook_at(0).webhook_header).to have_source
   end
 
-  it "allows for selection at an index" do
+  it "allows for selection at an index", :js do
     page = build_page(<<-HTML)
     <template id="item">
       <li>
@@ -174,12 +174,5 @@ RSpec.describe "has_many_ordered", type: :feature do
     expect(test_page.list_at(1, name: "List of 3 Items").items).to have_count_of(3)
     expect(test_page.list_at(2, name: "List of 2 Items").items).to have_count_of(2)
     expect(test_page).not_to have_list_at(2, name: "List of 3 Items")
-  end
-
-  def build_page(markup)
-    AppGenerator
-      .new
-      .route("/", markup)
-      .run(runner: :selenium_chrome_headless)
   end
 end

--- a/spec/features/has_many_spec.rb
+++ b/spec/features/has_many_spec.rb
@@ -76,11 +76,4 @@ RSpec.describe "has_many", type: :feature do
     expect(test_page.sections("Section").map(&:text)).to eq(["Section 1", "Section 2"])
     expect(test_page.sections("Bogus")).to be_empty
   end
-
-  def build_page(markup)
-    AppGenerator
-      .new
-      .route("/", markup)
-      .run
-  end
 end

--- a/spec/features/has_one_spec.rb
+++ b/spec/features/has_one_spec.rb
@@ -283,11 +283,4 @@ RSpec.describe "has_one", type: :feature do
     expect(test_page.form.name_field.value).to eq "Awesome Person"
     expect(test_page.form.email_field.value).to eq "person@example.com"
   end
-
-  def build_page(markup)
-    AppGenerator
-      .new
-      .route("/", markup)
-      .run
-  end
 end

--- a/spec/features/macros_with_methods_spec.rb
+++ b/spec/features/macros_with_methods_spec.rb
@@ -166,11 +166,4 @@ RSpec.describe "Macros with methods" do
     expect(test_page.items(state: "incomplete").first.name).to have_text("Buy eggs")
     expect(test_page.items(state: "incomplete")[1].name).to have_text("Buy onions")
   end
-
-  def build_page(markup)
-    AppGenerator
-      .new
-      .route("/", markup)
-      .run
-  end
 end

--- a/spec/features/selectors_spec.rb
+++ b/spec/features/selectors_spec.rb
@@ -58,11 +58,4 @@ RSpec.describe "Selectors" do
 
     expect(test_page).to have_heading
   end
-
-  def build_page(markup)
-    AppGenerator
-      .new
-      .route("/", markup)
-      .run
-  end
 end

--- a/spec/support/app_generator.rb
+++ b/spec/support/app_generator.rb
@@ -32,3 +32,22 @@ class AppGenerator
 
   attr_reader :app, :title
 end
+
+module BuildPage
+  def build_page(markup)
+    AppGenerator
+      .new
+      .route("/", markup)
+      .run(runner: @app_runner)
+  end
+end
+
+RSpec.configure do |config|
+  include BuildPage
+
+  config.around do |example|
+    @app_runner = (!!example.metadata[:js]) ? :selenium_chrome_headless : :rack_test
+
+    example.run
+  end
+end


### PR DESCRIPTION
What?
=====

Now that patterns have been established within the test suite, we can
safely extract the build_page helper method to a module that's mixed
into RSpec.

This also adjusts behavior to run via a headless browser by using
RSpec's `:js` metadata.
