### PR TITLE
Add complementary #has_no_{singular_name}_at? on has_many_ordered

### DIFF
--- a/lib/page_ez/method_generators/has_many_ordered_selector.rb
+++ b/lib/page_ez/method_generators/has_many_ordered_selector.rb
@@ -45,6 +45,15 @@ module PageEz
             **evaluator.options
           )
         end
+
+        target.logged_define_method("has_no_#{singularized_name}_at?") do |index, *args|
+          evaluator = evaluator_class.run(args, target: self)
+
+          has_no_css?(
+            build_selector[evaluator.selector, index],
+            **evaluator.options
+          )
+        end
       end
 
       def selector_type


### PR DESCRIPTION
What?
=====

This adds the complementary `#has_no_{singular_name}_at?` method to
elements declared as `has_many_ordered` and verifies correct behavior.
