### PR TITLE
Fix bug related to subclassing and macro reuse

### DIFF
--- a/lib/page_ez/page.rb
+++ b/lib/page_ez/page.rb
@@ -4,10 +4,11 @@ require "active_support/core_ext/class/attribute"
 module PageEz
   class Page
     include DelegatesTo[:container]
-    class_attribute :visitor, :macro_registrar
+    class_attribute :visitor, :macro_registrar, :nested_macro
 
     self.visitor = PageVisitor.new
     self.macro_registrar = {}
+    self.nested_macro = false
 
     undef_method :select
 
@@ -91,7 +92,7 @@ module PageEz
     end
 
     def self.inherited(subclass)
-      if ancestors.first == PageEz::Page
+      if !nested_macro
         visitor.reset
       end
 
@@ -100,6 +101,7 @@ module PageEz
 
     def self.constructor_from_block(superclass = nil, &block)
       if block
+        self.nested_macro = true
         Class.new(superclass || self).tap do |klass|
           visitor.begin_block_evaluation
           klass.macro_registrar = {}

--- a/spec/features/smoke_spec.rb
+++ b/spec/features/smoke_spec.rb
@@ -143,4 +143,24 @@ RSpec.describe "Smoke spec", type: :feature do
       end
     end.not_to raise_error
   end
+
+  it "allows for macros across PageEz::Page subclasses to refer to the same name" do
+    expect do
+      # rubocop:disable Lint/ConstantDefinitionInBlock
+      class ComposedPage < PageEz::Page
+      end
+
+      class BasePage < PageEz::Page
+      end
+
+      class OtherPageWithComposed < PageEz::Page
+        has_one :composed_page, "section.composed"
+      end
+
+      class PageWithComposed < BasePage
+        has_one :composed_page, ComposedPage
+      end
+      # rubocop:enable Lint/ConstantDefinitionInBlock
+    end.not_to raise_error
+  end
 end


### PR DESCRIPTION
What?
=====

This updates the logic when inheriting from a PageEz::Page class to
reset visitors properly.

Previously, we checked to see if the first ancestor when inheriting was
a `PageEz::Page`. However, this behavior isn't actually correct, as
subclassing occurs in two fashions: from a library usage perspective,
and internally when nesting macros, e.g.

Library usage via traditional inheritance:

```ruby
class ApplicationPage < PageEz::Page
end

class Homepage < ApplicationPage
end
```

Nesting macros:

```ruby
has_one :list, "ul" do
  has_many_ordered :items, "li"
end
```

In both cases, the `inherited` hook gets called, but visitors should
only be reset via traditional inheritance and NOT by nesting macros.

This introduces a new class attribute, `nested_macro`, which defaults to
false and is set to true when generating an anonymous class for evaluation of
nested macros.
