### PR TITLE
Add ability to define a base selector for a PageEz::Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,21 @@ todos_list.item_at(0).complete_button.click             # => find("li:nth-of-typ
 [`Capybara::Node::Finders#find`]: https://rubydoc.info/github/teamcapybara/capybara/Capybara/Node/Finders#find-instance_method
 [`Capybara::Node::Matchers#has_css?`]: https://rubydoc.info/github/teamcapybara/capybara/Capybara/Node/Matchers#has_css%3F-instance_method
 
+## Base Selectors
+
+Certain components may exist across multiple pages but have a base selector
+from which all interactions should be scoped.
+
+This can be configured on a per-object basis:
+
+```rb
+class ApplicationHeader < PageEz::Page
+  base_selector "header[data-role=primary]"
+
+  has_one :application_title, "h1"
+end
+```
+
 ## Page Object Composition
 
 Because page objects can encompass as much or as little of the DOM as desired,

--- a/lib/page_ez/method_generators/has_many_ordered_selector.rb
+++ b/lib/page_ez/method_generators/has_many_ordered_selector.rb
@@ -6,14 +6,14 @@ module PageEz
       def initialize(name, selector, dynamic_options, options, &block)
         @name = name
         @selector = selector
-        @base_selector = HasManyStaticSelector.new(name, selector, dynamic_options, options, &block)
+        @core_selector = HasManyStaticSelector.new(name, selector, dynamic_options, options, &block)
         @evaluator_class = SelectorEvaluator.build(@name, dynamic_options: dynamic_options, options: options, selector: selector)
       end
 
       def run(target)
         singularized_name = Pluralization.new(@name).singularize
 
-        constructor = @base_selector.run(target)
+        constructor = @core_selector.run(target)
 
         DefineHasOneResultMethods.new(
           "#{singularized_name}_at",
@@ -30,7 +30,7 @@ module PageEz
       end
 
       def selector_type
-        @base_selector.selector_type
+        @core_selector.selector_type
       end
 
       class IndexedProcessor

--- a/lib/page_ez/method_generators/has_one_composed_class.rb
+++ b/lib/page_ez/method_generators/has_one_composed_class.rb
@@ -16,13 +16,13 @@ module PageEz
         base_selector = @options.delete(:base_selector)
 
         target.logged_define_method(@name) do |*args|
-          container = if base_selector
-            find(base_selector)
+          if base_selector
+            Class.new(constructor).tap do |new_constructor|
+              new_constructor.base_selector base_selector
+            end.new(self)
           else
-            self
+            constructor.new(self)
           end
-
-          constructor.new(container)
         end
 
         if base_selector

--- a/lib/page_ez/page.rb
+++ b/lib/page_ez/page.rb
@@ -5,15 +5,26 @@ require "active_support/core_ext/module/delegation"
 module PageEz
   class Page
     include DelegatesTo[:container]
-    class_attribute :visitor, :macro_registrar, :nested_macro
+    class_attribute :visitor, :macro_registrar, :nested_macro, :container_base_selector
 
     self.visitor = PageVisitor.new
     self.macro_registrar = {}
     self.nested_macro = false
+    self.container_base_selector = nil
 
     undef_method :select
 
-    attr_reader :container
+    def container
+      if container_base_selector
+        @container.find(container_base_selector)
+      else
+        @container
+      end
+    end
+
+    def self.base_selector(value)
+      self.container_base_selector = value
+    end
 
     def initialize(container = nil)
       @container = container || Class.new do

--- a/lib/page_ez/page.rb
+++ b/lib/page_ez/page.rb
@@ -26,6 +26,21 @@ module PageEz
       self.container_base_selector = value
     end
 
+    def self.contains(page_object, only: nil)
+      delegation_target = :"__page_object_#{page_object.object_id}__"
+
+      has_one(delegation_target, page_object)
+
+      if only
+        methods_delegated_that_do_not_exist = only - page_object.instance_methods(false)
+        if methods_delegated_that_do_not_exist.any?
+          raise NoMethodError, "Attempting to delegate non-existent method(s) to #{page_object}: #{methods_delegated_that_do_not_exist.join(", ")}"
+        end
+      end
+
+      delegate(*(only || page_object.instance_methods(false)), to: delegation_target)
+    end
+
     def initialize(container = nil)
       @container = container || Class.new do
         include Capybara::DSL

--- a/spec/features/contains_spec.rb
+++ b/spec/features/contains_spec.rb
@@ -1,0 +1,250 @@
+require "spec_helper"
+
+RSpec.describe "contains" do
+  it "pulls in everything from the corresponding PageEz::Page" do
+    page = build_page(<<-HTML)
+    <heading data-role="primary">
+      <h1>Application Title</h1>
+    </heading>
+    <main>
+      <h2>Awesome Site</h2>
+    </main>
+    <footer data-role="primary">
+      <p data-role=copyright>Copyright 2023 Company Name</p>
+    </footer>
+    HTML
+
+    heading = Class.new(PageEz::Page) do
+      base_selector "heading[data-role=primary]"
+
+      has_one :application_title, "h1"
+    end
+
+    footer = Class.new(PageEz::Page) do
+      base_selector "footer[data-role=primary]"
+
+      has_one :copyright, "p[data-role=copyright]"
+
+      def awesome?
+        true
+      end
+    end
+
+    test_page = Class.new(PageEz::Page) do
+      contains heading
+      contains footer
+
+      has_one :main do
+        has_one :heading, "h2"
+      end
+    end.new(page)
+
+    page.visit "/"
+
+    expect(test_page.application_title).to have_text("Application Title")
+    expect(test_page).to have_application_title(text: "Application Title")
+
+    expect(test_page.main).to have_heading(text: "Awesome Site")
+    expect(test_page).to have_copyright(text: "Copyright 2023 Company Name")
+    expect(test_page).to be_awesome
+  end
+
+  it "allows multiple page objects to use contains with the same page object" do
+    expect do
+      heading = Class.new(PageEz::Page) do
+        has_one :header
+      end
+
+      Class.new(PageEz::Page) do
+        contains heading
+      end
+
+      Class.new(PageEz::Page) do
+        contains heading
+      end
+    end.not_to raise_error
+  end
+
+  it "allows for delegating only a subset of methods" do
+    page = build_page(<<-HTML)
+    <heading data-role="primary">
+      <h1>Application Title</h1>
+    </heading>
+    <main>
+      <h2>Awesome Site</h2>
+    </main>
+    <footer data-role="primary">
+      <p data-role=copyright>Copyright 2023 Company Name</p>
+    </footer>
+    HTML
+
+    footer = Class.new(PageEz::Page) do
+      base_selector "footer[data-role=primary]"
+
+      has_one :copyright, "p[data-role=copyright]"
+
+      def awesome?
+        true
+      end
+    end
+
+    test_page = Class.new(PageEz::Page) do
+      contains footer, only: %i[has_copyright?]
+
+      def awesome?
+        false
+      end
+    end.new(page)
+
+    page.visit "/"
+
+    expect(test_page).to have_copyright(text: "Copyright 2023 Company Name")
+    expect(test_page).not_to be_awesome
+  end
+
+  it "applies base selectors to contained pages" do
+    page = build_page(<<-HTML)
+    <ul data-role="complete-todos">
+      <li data-role="todo">
+        <span data-role="name">Buy milk</span>
+        <button data-role="toggle-complete">Mark Incomplete</button>
+      </li>
+    </ul>
+    <ul data-role="incomplete-todos">
+      <li data-role="todo">
+        <span data-role="name">Buy eggs</span>
+        <button data-role="toggle-complete">Mark Complete</button>
+      </li>
+    </ul>
+    HTML
+
+    todo_list = Class.new(PageEz::Page) do
+      has_many_ordered :items, "li[data-role=todo]" do
+        has_one :name, "span[data-role=name]"
+        has_one :toggle_complete_button, "[data-role=toggle-complete]"
+      end
+    end
+
+    complete_todos = Class.new(PageEz::Page) do
+      base_selector "ul[data-role=complete-todos]"
+
+      contains todo_list
+    end.new(page)
+
+    incomplete_todos = Class.new(PageEz::Page) do
+      base_selector "ul[data-role=incomplete-todos]"
+
+      contains todo_list
+    end.new(page)
+
+    page.visit "/"
+
+    expect(complete_todos.item_at(0)).to have_name(text: "Buy milk")
+    expect(complete_todos.item_at(0)).to have_toggle_complete_button(text: "Mark Incomplete")
+
+    expect(incomplete_todos.item_at(0)).to have_name(text: "Buy eggs")
+    expect(incomplete_todos.item_at(0)).to have_toggle_complete_button(text: "Mark Complete")
+  end
+
+  it "raises when macros collide" do
+    nav = Class.new(PageEz::Page) do
+      has_many :links, "a"
+    end
+
+    expect do
+      Class.new(PageEz::Page) do
+        contains nav
+
+        has_many :links, "li a"
+      end
+    end.to raise_error(PageEz::DuplicateElementDeclarationError)
+
+    expect do
+      Class.new(PageEz::Page) do
+        has_many :links, "li a"
+
+        contains nav
+      end
+    end.to raise_error(PageEz::DuplicateElementDeclarationError)
+  end
+
+  it "raises when instance methods collide" do
+    nav = Class.new(PageEz::Page) do
+      def awesome?
+        true
+      end
+    end
+
+    expect do
+      Class.new(PageEz::Page) do
+        contains nav
+
+        def awesome?
+          false
+        end
+      end
+    end.to raise_error(PageEz::DuplicateElementDeclarationError)
+
+    expect do
+      Class.new(PageEz::Page) do
+        def awesome?
+          false
+        end
+
+        contains nav
+      end
+    end.to raise_error(PageEz::DuplicateElementDeclarationError)
+  end
+
+  it "raises when instance methods collide with element names" do
+    nav = Class.new(PageEz::Page) do
+      has_many :links, "a"
+    end
+
+    expect do
+      Class.new(PageEz::Page) do
+        contains nav
+
+        def links
+          "whoops"
+        end
+      end
+    end.to raise_error(PageEz::DuplicateElementDeclarationError)
+
+    expect do
+      Class.new(PageEz::Page) do
+        def links
+          "whoops"
+        end
+
+        contains nav
+      end
+    end.to raise_error(PageEz::DuplicateElementDeclarationError)
+  end
+
+  it "does not raise when instance methods collide with element names in nested pages" do
+    nav = Class.new(PageEz::Page) do
+      has_many :links, "a"
+    end
+
+    expect do
+      Class.new(PageEz::Page) do
+        contains nav
+
+        has_one :header do
+          has_many :links, "a"
+        end
+      end
+    end.not_to raise_error
+  end
+
+  it "raises NoMethodError when attempting to contains->delegate a method that does not exist" do
+    footer = Class.new(PageEz::Page)
+
+    expect do
+      Class.new(PageEz::Page) do
+        contains footer, only: %i[bogus]
+      end
+    end.to raise_error(NoMethodError, /Attempting to delegate.*to #{footer}: bogus/)
+  end
+end

--- a/spec/features/override_container_spec.rb
+++ b/spec/features/override_container_spec.rb
@@ -1,0 +1,150 @@
+require "spec_helper"
+
+RSpec.describe "overriding container" do
+  it "works by scoping the first portion" do
+    page = build_page(<<-HTML)
+    <div data-role="slot-1">
+      <section>
+        <heading>
+          <h2>Heading 1</h2>
+        </heading>
+        <div data-role="content">
+          <p>Paragraph 1</p>
+          <p>Paragraph 2</p>
+          <p>Paragraph 3</p>
+        </div>
+      </section>
+    </div>
+    <div data-role="slot-2">
+      <section>
+        <heading>
+          <h2>Heading 2</h2>
+        </heading>
+        <div data-role="content">
+          <p>Paragraph 4</p>
+          <p>Paragraph 5</p>
+          <p>Paragraph 6</p>
+        </div>
+      </section>
+    </div>
+    HTML
+
+    test_page = Class.new(PageEz::Page) do
+      has_one :section do
+        has_one :heading do
+          has_one :body, "h2"
+        end
+
+        has_one :primary_content, "[data-role=content]" do
+          has_many_ordered :paragraphs, "p"
+        end
+      end
+    end
+
+    slot_one_class = Class.new(test_page) do
+      base_selector "[data-role=slot-1]"
+    end
+
+    slot_two_class = Class.new(test_page) do
+      base_selector "[data-role=slot-2]"
+    end
+
+    sub_slot_one = Class.new(slot_one_class).new(page)
+
+    page.visit "/"
+
+    aggregate_failures "composition works with classes that have a base_selector already defined" do
+      wrapper = Class.new(PageEz::Page) do
+        has_one :slot_one, slot_one_class
+        has_one :slot_two, slot_two_class
+      end.new(page)
+
+      expect(wrapper.slot_one).to match_slot_one_values
+      expect(wrapper.slot_two).to match_slot_two_values
+    end
+
+    aggregate_failures "composition works with classes that have a base_selector already defined" do
+      wrapper = Class.new(PageEz::Page) do
+        has_one :slot_one_flipped, slot_one_class, base_selector: "[data-role=slot-2]"
+        has_one :slot_two_flipped, slot_two_class, base_selector: "[data-role=slot-1]"
+      end.new(page)
+
+      expect(wrapper.slot_two_flipped).to match_slot_one_values
+      expect(wrapper.slot_one_flipped).to match_slot_two_values
+    end
+
+    aggregate_failures "composition sets the base_selector when no base selector is set" do
+      wrapper = Class.new(PageEz::Page) do
+        has_one :slot_one, test_page, base_selector: "[data-role=slot-1]"
+        has_one :slot_two, test_page, base_selector: "[data-role=slot-2]"
+      end.new(page)
+
+      expect(wrapper.slot_one).to match_slot_one_values
+      expect(wrapper.slot_two).to match_slot_two_values
+    end
+
+    aggregate_failures "#within scopes to the correct container" do
+      within "[data-role=slot-1]" do
+        expect(test_page.new(page)).to match_slot_one_values
+      end
+
+      within "[data-role=slot-2]" do
+        expect(test_page.new(page)).to match_slot_two_values
+      end
+    end
+
+    aggregate_failures "no base_selector results in ambiguous matches" do
+      expect do
+        test_page.new(page).section
+      end.to raise_error(Capybara::Ambiguous)
+
+      expect do
+        Class.new(slot_one_class) do
+          base_selector nil
+        end.new(page).section
+      end.to raise_error(Capybara::Ambiguous)
+    end
+
+    expect(sub_slot_one).to match_slot_one_values
+    expect(slot_one_class.new(page)).to match_slot_one_values
+    expect(slot_two_class.new(page)).to match_slot_two_values
+  end
+
+  def match_slot_one_values
+    MatchesSlotOne.new
+  end
+
+  def match_slot_two_values
+    MatchesSlotTwo.new
+  end
+
+  # rubocop:disable Lint/ConstantDefinitionInBlock
+  class MatchesSlotOne
+    def matches?(target)
+      @target = target
+      @target.section.heading.has_body?(text: "Heading 1") &&
+        @target.section.primary_content.has_paragraph_at?(0, text: "Paragraph 1") &&
+        @target.section.primary_content.has_paragraph_at?(1, text: "Paragraph 2") &&
+        @target.section.primary_content.has_paragraph_at?(2, text: "Paragraph 3")
+    end
+
+    def failure_message
+      "expected #{@target} to match slot one values"
+    end
+  end
+
+  class MatchesSlotTwo
+    def matches?(target)
+      @target = target
+      @target.section.heading.has_body?(text: "Heading 2") &&
+        @target.section.primary_content.has_paragraph_at?(0, text: "Paragraph 4") &&
+        @target.section.primary_content.has_paragraph_at?(1, text: "Paragraph 5") &&
+        @target.section.primary_content.has_paragraph_at?(2, text: "Paragraph 6")
+    end
+
+    def failure_message
+      "expected #{@target} to match slot two values"
+    end
+  end
+  # rubocop:enable Lint/ConstantDefinitionInBlock
+end


### PR DESCRIPTION
This introduces `base_selector` and `contains` to allow for a different approach to page object composition.

```rb
class SidebarModal < PageEz::Page
  base_selector "div[data-role=sidebar]"

  has_one :sidebar_heading, "h2"
  has_one :sidebar_contents, "section[data-role=contents]"
end

class PeopleIndex < PageEz::Page
  contains SidebarModal

  has_many :people_rows, "ul[data-role=people-list] li" do
    has_one :name, "span[data-role=person-name]"
    has_one :edit_link, "a", text: "Edit"
  end

  def change_person_name(from:, to:)
    people_row_matching(text: from).edit_link.click

    within sidebar_contents do
      fill_in "Name", with: to
      click_on "Save Person"
    end
  end
end
```