### PR TITLE
Reraise with an improved message on invalid CSS selectors

### DIFF
--- a/lib/page_ez/errors.rb
+++ b/lib/page_ez/errors.rb
@@ -6,4 +6,12 @@ module PageEz
   class MatcherCollisionError < StandardError; end
 
   class DuplicateElementDeclarationError < StandardError; end
+
+  class InvalidSelectorError < StandardError; end
+
+  def self.reraise_selector_error(selector)
+    yield
+  rescue Nokogiri::CSS::SyntaxError => e
+    raise InvalidSelectorError, "Invalid selector '#{selector}':\n#{e.message}"
+  end
 end

--- a/lib/page_ez/method_generators/define_has_many_result_methods.rb
+++ b/lib/page_ez/method_generators/define_has_many_result_methods.rb
@@ -19,12 +19,16 @@ module PageEz
         target.logged_define_method(name) do |*args|
           evaluator = evaluator_class.run(processor.run_args(args), target: self)
 
-          PageEz::HasManyResult.new(
-            container: container,
-            selector: processor.selector(evaluator.selector, args),
-            options: evaluator.options,
-            constructor: constructor.method(:new)
-          )
+          selector = processor.selector(evaluator.selector, args)
+
+          PageEz.reraise_selector_error(selector) do
+            PageEz::HasManyResult.new(
+              container: container,
+              selector: selector,
+              options: evaluator.options,
+              constructor: constructor.method(:new)
+            )
+          end
         end
 
         target.logged_define_method("has_#{name}_count?") do |count, *args|

--- a/lib/page_ez/method_generators/define_has_one_predicate_methods.rb
+++ b/lib/page_ez/method_generators/define_has_one_predicate_methods.rb
@@ -14,19 +14,27 @@ module PageEz
         target.logged_define_method("has_#{@name}?") do |*args|
           evaluator = evaluator_class.run(processor.run_args(args), target: self)
 
-          has_css?(
-            processor.selector(evaluator.selector, args),
-            **evaluator.options
-          )
+          selector = processor.selector(evaluator.selector, args)
+
+          PageEz.reraise_selector_error(selector) do
+            has_css?(
+              selector,
+              **evaluator.options
+            )
+          end
         end
 
         target.logged_define_method("has_no_#{@name}?") do |*args|
           evaluator = evaluator_class.run(processor.run_args(args), target: self)
 
-          has_no_css?(
-            processor.selector(evaluator.selector, args),
-            **evaluator.options
-          )
+          selector = processor.selector(evaluator.selector, args)
+
+          PageEz.reraise_selector_error(selector) do
+            has_no_css?(
+              selector,
+              **evaluator.options
+            )
+          end
         end
       end
     end

--- a/lib/page_ez/method_generators/define_has_one_result_methods.rb
+++ b/lib/page_ez/method_generators/define_has_one_result_methods.rb
@@ -18,12 +18,16 @@ module PageEz
         target.logged_define_method(@name) do |*args|
           evaluator = evaluator_class.run(processor.run_args(args), target: self)
 
-          PageEz::HasOneResult.new(
-            container: container,
-            selector: processor.selector(evaluator.selector, args),
-            options: evaluator.options,
-            constructor: constructor.method(:new)
-          )
+          selector = processor.selector(evaluator.selector, args)
+
+          PageEz.reraise_selector_error(selector) do
+            PageEz::HasOneResult.new(
+              container: container,
+              selector: selector,
+              options: evaluator.options,
+              constructor: constructor.method(:new)
+            )
+          end
         end
       end
     end

--- a/spec/features/broken_selector_spec.rb
+++ b/spec/features/broken_selector_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+
+RSpec.describe "generating broken CSS selectors", :feature do
+  it "provides more context around what selector was used" do
+    page = build_page(<<-HTML)
+    <section>Bogus</section>
+    HTML
+
+    test_page = Class.new(PageEz::Page) do
+      has_one :dynamic_section
+      has_one :section_assuming_dynamic_section_can_be_interpolated
+      has_many :sections_assuming_dynamic_section_can_be_interpolated
+
+      def dynamic_section(_)
+        "section"
+      end
+
+      def section_assuming_dynamic_section_can_be_interpolated
+        # dynamic_section("value") returns a HasOneResult rather than a string,
+        # which is rendered as "#<PageEz::HasOneResult...> [data-role=has_one-wont-work]"
+        "#{dynamic_section("value")} [data-role=has_one-wont-work]"
+      end
+
+      def sections_assuming_dynamic_section_can_be_interpolated
+        # dynamic_section("value") returns a HasOneResult rather than a string,
+        # which is rendered as "#<PageEz::HasOneResult...> [data-role=has_many-wont-work]"
+        "#{dynamic_section("value")} [data-role=has_many-wont-work]"
+      end
+    end.new(page)
+
+    page.visit "/"
+
+    expect {
+      test_page.section_assuming_dynamic_section_can_be_interpolated
+    }.to raise_error(PageEz::InvalidSelectorError, /^Invalid selector '#<PageEz::HasOneResult.*\[data-role=has_one-wont-work\]'/)
+
+    expect {
+      test_page.has_section_assuming_dynamic_section_can_be_interpolated?
+    }.to raise_error(PageEz::InvalidSelectorError, /^Invalid selector '#<PageEz::HasOneResult.*\[data-role=has_one-wont-work\]'/)
+
+    expect {
+      test_page.has_no_section_assuming_dynamic_section_can_be_interpolated?
+    }.to raise_error(PageEz::InvalidSelectorError, /^Invalid selector '#<PageEz::HasOneResult.*\[data-role=has_one-wont-work\]'/)
+
+    expect {
+      test_page.sections_assuming_dynamic_section_can_be_interpolated
+    }.to raise_error(PageEz::InvalidSelectorError, /^Invalid selector '#<PageEz::HasOneResult.*\[data-role=has_many-wont-work\]'/)
+
+    expect {
+      test_page.has_sections_assuming_dynamic_section_can_be_interpolated_count?(1)
+    }.to raise_error(PageEz::InvalidSelectorError, /^Invalid selector '#<PageEz::HasOneResult.*\[data-role=has_many-wont-work\]'/)
+  end
+end


### PR DESCRIPTION
What?
=====

Nokogiri's CSS::SyntaxError exception does not include the full selector
in its exception, making it hard to understand why exactly a selector
isn't working, especially in tools like PageEz which generates some
selectors dynamically.
