### PR TITLE
Track name registration for delegated methods

### DIFF
--- a/lib/page_ez/page.rb
+++ b/lib/page_ez/page.rb
@@ -1,5 +1,6 @@
 require "capybara/dsl"
 require "active_support/core_ext/class/attribute"
+require "active_support/core_ext/module/delegation"
 
 module PageEz
   class Page
@@ -25,6 +26,14 @@ module PageEz
 
       if macro_registrar.key?(name)
         macro_registrar[name].run(self)
+      end
+    end
+
+    def self.delegate(...)
+      super(...).tap do |method_names|
+        method_names.each do |method_name|
+          visitor.track_method_delegated(method_name)
+        end
       end
     end
 

--- a/lib/page_ez/page_visitor.rb
+++ b/lib/page_ez/page_visitor.rb
@@ -51,6 +51,12 @@ module PageEz
       end
     end
 
+    def track_method_delegated(name)
+      @visitors.each do |visitor|
+        visitor.track_method_delegated(name)
+      end
+    end
+
     def process_macro(macro, name, construction_strategy)
       @visitors.each do |visitor|
         visitor.process_macro(macro, name, construction_strategy)

--- a/lib/page_ez/visitors/debug_visitor.rb
+++ b/lib/page_ez/visitors/debug_visitor.rb
@@ -35,6 +35,11 @@ module PageEz
         @depth_visitor.track_method_renamed(from, to)
       end
 
+      def track_method_delegated(name)
+        @depth_visitor.track_method_delegated(name)
+        debug("* #{name} (delegated)")
+      end
+
       def process_macro(macro, name, construction_strategy)
         @depth_visitor.process_macro(macro, name, construction_strategy)
         debug("#{macro} :#{name}, \"#{construction_strategy.selector}\"")

--- a/lib/page_ez/visitors/depth_visitor.rb
+++ b/lib/page_ez/visitors/depth_visitor.rb
@@ -30,6 +30,9 @@ module PageEz
       def track_method_renamed(*)
       end
 
+      def track_method_delegated(*)
+      end
+
       def process_macro(*)
       end
 

--- a/lib/page_ez/visitors/macro_pluralization_visitor.rb
+++ b/lib/page_ez/visitors/macro_pluralization_visitor.rb
@@ -33,6 +33,10 @@ module PageEz
         @depth_visitor.track_method_renamed(from, to)
       end
 
+      def track_method_delegated(name)
+        @depth_visitor.track_method_delegated(name)
+      end
+
       def process_macro(macro, name, construction_strategy)
         @depth_visitor.process_macro(macro, name, construction_strategy)
         rendered = "#{macro} :#{name}, \"#{construction_strategy.selector}\""

--- a/lib/page_ez/visitors/matcher_collision_visitor.rb
+++ b/lib/page_ez/visitors/matcher_collision_visitor.rb
@@ -33,6 +33,10 @@ module PageEz
         @depth_visitor.track_method_renamed(from, to)
       end
 
+      def track_method_delegated(name)
+        @depth_visitor.track_method_delegated(name)
+      end
+
       def process_macro(macro, name, construction_strategy)
         @depth_visitor.process_macro(macro, name, construction_strategy)
         if existing_matchers.include?(name.to_s)

--- a/lib/page_ez/visitors/registered_name_visitor.rb
+++ b/lib/page_ez/visitors/registered_name_visitor.rb
@@ -27,6 +27,14 @@ module PageEz
         current_renamed_methods.push(from)
       end
 
+      def track_method_delegated(name)
+        if current_all_methods.count { _1 == name } > 1
+          raise DuplicateElementDeclarationError, "duplicate element :#{name} declared"
+        end
+
+        current_delegated_methods.push(name)
+      end
+
       def track_method_added(name, construction_strategy)
         @declared_constructors[parent_id] ||= []
 
@@ -37,6 +45,10 @@ module PageEz
         end
 
         if current_renamed_methods.include?(name) && current_all_methods.include?(name)
+          raise DuplicateElementDeclarationError, "duplicate element :#{name} declared"
+        end
+
+        if current_delegated_methods.include?(name) && current_all_methods.include?(name)
           raise DuplicateElementDeclarationError, "duplicate element :#{name} declared"
         end
 
@@ -59,6 +71,7 @@ module PageEz
         @current_strategy = nil
         @declared_constructors = {}
         @all_methods = {}
+        @delegated_methods = {}
         @renamed_methods = {}
       end
 
@@ -76,6 +89,11 @@ module PageEz
       def current_all_methods
         @all_methods[parent_id] ||= []
         @all_methods[parent_id]
+      end
+
+      def current_delegated_methods
+        @delegated_methods[parent_id] ||= []
+        @delegated_methods[parent_id]
       end
     end
   end

--- a/spec/features/delegation_name_collisions_spec.rb
+++ b/spec/features/delegation_name_collisions_spec.rb
@@ -1,0 +1,135 @@
+require "spec_helper"
+
+RSpec.describe "Delegation name collisions" do
+  it "raises when a name collides" do
+    expect do
+      Class.new(PageEz::Page) do
+        has_one :header do
+          has_one :application_title, "h1"
+        end
+
+        delegate :application_title, to: :header
+
+        def application_title
+          "redeclared"
+        end
+      end
+    end.to raise_error(PageEz::DuplicateElementDeclarationError)
+
+    expect do
+      Class.new(PageEz::Page) do
+        has_one :header do
+          has_one :application_title, "h1"
+        end
+
+        def application_title
+          "redeclared"
+        end
+
+        delegate :application_title, to: :header
+      end
+    end.to raise_error(PageEz::DuplicateElementDeclarationError)
+  end
+
+  it "handles collision tracking when methods are prefixed" do
+    expect do
+      Class.new(PageEz::Page) do
+        has_one :header do
+          has_one :application_title, "h1"
+        end
+
+        delegate :application_title, to: :header, prefix: :awesome
+
+        def awesome_application_title
+          "redeclared"
+        end
+      end
+    end.to raise_error(PageEz::DuplicateElementDeclarationError)
+
+    expect do
+      Class.new(PageEz::Page) do
+        has_one :header do
+          has_one :application_title, "h1"
+        end
+
+        def awesome_application_title
+          "redeclared"
+        end
+
+        delegate :application_title, to: :header, prefix: :awesome
+      end
+    end.to raise_error(PageEz::DuplicateElementDeclarationError)
+
+    expect do
+      Class.new(PageEz::Page) do
+        has_one :header do
+          has_one :application_title, "h1"
+        end
+
+        def header_application_title
+          "redeclared"
+        end
+
+        delegate :application_title, to: :header, prefix: true
+      end
+    end.to raise_error(PageEz::DuplicateElementDeclarationError)
+  end
+
+  it "does not raise when collisions do not occur" do
+    expect do
+      Class.new(PageEz::Page) do
+        has_one :header do
+          has_one :application_title, "h1"
+        end
+
+        delegate :application_title, to: :header, prefix: :awesome
+
+        def application_title
+          "different than prefixed"
+        end
+      end
+    end.not_to raise_error
+
+    expect do
+      Class.new(PageEz::Page) do
+        has_one :header do
+          has_one :application_title, "h1"
+        end
+
+        def application_title
+          "redeclared"
+        end
+
+        delegate :application_title, to: :header, prefix: :awesome
+      end
+    end.not_to raise_error
+
+    expect do
+      Class.new(PageEz::Page) do
+        has_one :header do
+          has_one :application_title, "h1"
+        end
+
+        def application_title
+          "redeclared"
+        end
+
+        delegate :application_title, to: :header, prefix: true
+      end
+    end.not_to raise_error
+  end
+
+  it "raises exceptions from the underlying delegate logic from ActiveSupport" do
+    expect do
+      Class.new(PageEz::Page) do
+        delegate :application_title
+      end
+    end.to raise_error(ArgumentError)
+
+    expect do
+      Class.new(PageEz::Page) do
+        delegate :application_title, to: nil
+      end
+    end.to raise_error(ArgumentError)
+  end
+end


### PR DESCRIPTION
What?
=====

In addition to macro declaration and defining methods normally,
developers can delegate methods to other instance methods.

This decorates `delegate` to track the "final form" of each method (as
the `to` and `prefix` options impact the resulting method name) and
handle collisions as it does in other instances. Just as in other
instances, the depth of nesting impacts collisions appropriately.
