### PR TITLE
Implement documented predicate methods for has_many

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ todos_index.has_no_todo_matching?(text: "Buy milk") # => has_no_css?("ul li span
 
 todos_index.todos.has_count_of?(number)             # => has_css?("ul li span[data-role=todo-name]", count: number)
 todos_index.has_todos_count?(number)                # => has_css?("ul li span[data-role=todo-name]", count: number)
+
+todos_index.todos.has_any_elements?                 # => has_css?("ul li span[data-role=todo-name]")
+todos_index.todos.has_no_elements?                  # => has_no_css?("ul li span[data-role=todo-name]")
 ```
 
 The methods defined by PageEz can be passed additional options from Capybara. Refer to documentation for the following methods:

--- a/lib/page_ez/has_many_result.rb
+++ b/lib/page_ez/has_many_result.rb
@@ -20,5 +20,16 @@ module PageEz
         **@options.merge(count: count)
       )
     end
+
+    def has_any_elements?
+      @container.has_css?(
+        @selector,
+        **@options
+      )
+    end
+
+    def has_no_elements?
+      @container.has_no_css?(@selector, **@options)
+    end
   end
 end

--- a/lib/page_ez/method_generators/define_has_many_result_methods.rb
+++ b/lib/page_ez/method_generators/define_has_many_result_methods.rb
@@ -34,6 +34,14 @@ module PageEz
         target.logged_define_method("has_#{name}_count?") do |count, *args|
           send(name, *args).has_count_of?(count)
         end
+
+        target.logged_define_method("has_#{name}?") do |*args|
+          send(name, *args).has_any_elements?
+        end
+
+        target.logged_define_method("has_no_#{name}?") do |*args|
+          send(name, *args).has_no_elements?
+        end
       end
     end
   end

--- a/spec/features/has_many_spec.rb
+++ b/spec/features/has_many_spec.rb
@@ -87,4 +87,47 @@ RSpec.describe "has_many", type: :feature do
     expect(test_page.sections("Section").map(&:text)).to eq(["Section 1", "Section 2"])
     expect(test_page.sections("Bogus")).to be_empty
   end
+
+  it "allows for checking for any or no elements" do
+    page = build_page(<<-HTML)
+    <div>
+      <ul>
+        <li>1-1</li>
+        <li>1-2</li>
+        <li>1-3</li>
+      </ul>
+
+      <ul>
+      </ul>
+    </div>
+    HTML
+
+    test_page = Class.new(PageEz::Page) do
+      has_one :first_list, "ul:nth-of-type(1)" do
+        has_many :items, "li"
+      end
+
+      has_one :second_list, "ul:nth-of-type(2)" do
+        has_many :items, "li"
+      end
+
+      has_one :third_list, "ul:nth-of-type(3)" do
+        has_many :items, "li"
+      end
+    end.new(page)
+
+    page.visit "/"
+
+    expect(test_page.first_list.items).to have_any_elements
+    expect(test_page.first_list.items).not_to have_no_elements
+
+    expect(test_page.second_list.items).not_to have_any_elements
+    expect(test_page.second_list.items).to have_no_elements
+
+    expect(test_page.first_list).to have_items
+    expect(test_page.first_list).not_to have_no_items
+
+    expect(test_page.second_list).not_to have_items
+    expect(test_page.second_list).to have_no_items
+  end
 end


### PR DESCRIPTION
What?
=====

This implements methods that were documented (incorrectly, as they
didn't exist yet) for asserting some or no elements matching a has_many.
