### PR TITLE
Fix inheritance bug that doesn't reset state correctly

### DIFF
--- a/lib/page_ez/page.rb
+++ b/lib/page_ez/page.rb
@@ -142,6 +142,7 @@ module PageEz
           klass.macro_registrar = {}
           klass.class_eval(&block)
           visitor.end_block_evaluation
+          self.nested_macro = false
         end
       elsif superclass
         superclass

--- a/spec/features/smoke_spec.rb
+++ b/spec/features/smoke_spec.rb
@@ -163,4 +163,21 @@ RSpec.describe "Smoke spec", type: :feature do
       # rubocop:enable Lint/ConstantDefinitionInBlock
     end.not_to raise_error
   end
+
+  it "allows for inheritance where macros do not collide" do
+    expect do
+      composed_page = Class.new(PageEz::Page) do
+        has_one :nested, "section" do
+        end
+      end
+
+      Class.new(PageEz::Page) do
+        has_one :list, "ul"
+      end
+
+      Class.new(composed_page) do
+        has_one :list, "ul"
+      end
+    end.not_to raise_error
+  end
 end


### PR DESCRIPTION
What?
=====

This addresses a bug with a very specific set of criteria for
reproduction:

* a page object (A) inheriting from PageEz::Page with a macro declaring
  a block (nothing needs to be declared in the block)
* a page object (B) inheriting from PageEz::Page that declares a top-level
  macro named (X)
* a page object (C) inheriting from (A) that also declares a top-level
  macro named (X)

The bug that triggered this failure (a duplicate element declaration
error, which would be on (X) in the example above) was related to a
state change (setting nested_macro to true) when a block is provided to
a macro that wasn't reset after the block was complete.

When a class inherits from PageEz or its subclasses, if it's not nested,
it resets all its visitors. This key behavior wasn't being triggered on
(C), resulting in it finding the same macro (X) from (B) and determining
that it was a collision.
